### PR TITLE
Add rbac users for search benchmark script

### DIFF
--- a/acm-deploy-load/benchmark-search.py
+++ b/acm-deploy-load/benchmark-search.py
@@ -112,7 +112,7 @@ def getTotalResourceCount(URL, TOKEN):
     if "errors" in qd_json:
       logger.error("GraphQL error encountered on resource count query: {}".format(qd_json["errors"][0]["message"]))
     elif "data" in qd_json and "searchResult" in qd_json["data"]:
-      logger.info("TotalResourceCount: {}".format(qd_json["data"]["searchResult"][0]["count"]))
+      logger.info("Total resource count for user: {}".format(qd_json["data"]["searchResult"][0]["count"]))
       return qd_json["data"]["searchResult"][0]["count"]
   else:
     logger.error("Error while parsing resource count response")
@@ -134,9 +134,9 @@ def measureQuery(URL, TOKEN, numRequests, queryData, queryName):
       if "errors" in qd_json:
         logger.error("GraphQL error encountered on {} iteration {}: {}".format(qd_json["errors"][0]["message"]))
       elif "data" in qd_json and "searchResult" in qd_json["data"]:
-        logger.info("search query data length: {}".format(len(qd_json["data"]["searchResult"][0]["items"])))
+        logger.debug("{} data length: {}".format(queryName, len(qd_json["data"]["searchResult"][0]["items"])))
       elif "data" in qd_json and "searchComplete" in qd_json["data"]:
-        logger.info("autocomplete data length: {}".format(len(qd_json["data"]["searchComplete"])))
+        logger.debug("{} data length: {}".format(queryName, len(qd_json["data"]["searchComplete"])))
     else:
       logger.error("Search query status code returned: {}".format(query_data.status_code))
       logger.error("Error encountered on {} iteration {}: {}".format(queryName, x, query_data.text.rstrip()))

--- a/acm-deploy-load/benchmark-search.py
+++ b/acm-deploy-load/benchmark-search.py
@@ -152,7 +152,7 @@ def measureQuery(URL, TOKEN, numRequests, queryData, queryName):
 
   avg = tempAvg / len(queryResArray)
   # should error be returned if there is one?
-  return min, max, avg
+  return "{:.3f}".format(min), "{:.3f}".format(max), "{:.3f}".format(avg)
 
 def main():
   # create csv file for results

--- a/acm-deploy-load/benchmark-search.py
+++ b/acm-deploy-load/benchmark-search.py
@@ -23,12 +23,15 @@ import logging
 import time
 import json
 import sys
+import requests
+import urllib3
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s : %(levelname)s : %(threadName)s : %(message)s")
 logger = logging.getLogger("acm-deploy-load")
 logging.Formatter.converter = time.gmtime
 
-# testUsers = ["search-admin"]
 testUsers = ["search-admin", "search-limited-access-user", "search-wide-access-user"]
 userClusterCounts = [0, 0, 0]
 
@@ -57,7 +60,7 @@ def createUsers():
   # create cluster-admin svcAccount
   createAdminSvcAcct_cmd = ["oc", "create", "serviceaccount", testUsers[0], "-n", "open-cluster-management"]
   adminrc1, adminoutput1 = command(createAdminSvcAcct_cmd, False, no_log=True)
-  createAdminRoleBinding_cmd = ["oc", "create", "rolebinding", testUsers[0], "--role=cluster-admin", "--serviceaccount=open-cluster-management:{}".format(testUsers[0])]
+  createAdminRoleBinding_cmd = ["oc", "create", "clusterrolebinding", testUsers[0], "--clusterrole=cluster-admin", "--serviceaccount=open-cluster-management:{}".format(testUsers[0])]
   adminrc2, adminoutput2 = command(createAdminRoleBinding_cmd, False, no_log=True)
   if (adminrc1 != 0 and adminoutput1.find('already exists') == -1) or (adminrc2 != 0 and adminoutput2.find('already exists') == -1):
     logger.error("Error creating {} test user".format(testUsers[0]))
@@ -75,44 +78,43 @@ def createUsers():
     logger.error("Error creating {} test user".format(testUsers[2]))
 
   # create Role that gives users access to cluster resources in search
-  createRole_cmd = ["oc", "create", "role", "managed-cluster-access", "--verb", "create,get,list,watch", "--resource", "managedclusterviews.view.open-cluster-management.io", "-n", "open-cluster-management"]
+  createRole_cmd = ["oc", "create", "clusterrole", "managed-cluster-access", "--verb", "create,get,list,watch", "--resource", "managedclusterviews.view.open-cluster-management.io"]
   roleRC, roleOutput = command(createRole_cmd, False, no_log=True)
   if (roleRC != 0 and roleOutput.find('already exists') == -1):
     logger.error("Error creating managedCluster Role: {}".format(roleRC))
 
   clusterList = getManagedClusterList()
   userClusterCounts[0] = len(clusterList)
-  for cluster in range(len(clusterList)):
-    # if cluster index is less than 10 create rolebinding for both users
-    if cluster < 10:
-      userClusterCounts[1] += 1
-      userClusterCounts[2] += 1
-      createManagedClusterRoleBinding_cmd = ["oc", "create", "rolebinding", clusterList[cluster], "--role", "managed-cluster-access", "--serviceaccount", "open-cluster-management:{}".format(testUsers[1]), "--serviceaccount", "open-cluster-management:{}".format(testUsers[2]),  "-n",  clusterList[cluster]]
-      roleBindingRC, roleBindingOutput = command(createManagedClusterRoleBinding_cmd, False, no_log=True)
-      if (roleBindingRC != 0 and roleBindingOutput.find('already exists') == -1):
-        logger.error("Error creating RoleBinding for cluster {}: {}".format(clusterList[cluster], roleRC))
-    # if cluster index is >= 10 create rolebinding for only wide access user (user get access to all but 10 clusters)
-    elif cluster >= 10 and (cluster < len(clusterList) - 10):
-      userClusterCounts[2] += 1
-      createManagedClusterRoleBinding_cmd = ["oc", "create", "rolebinding", clusterList[cluster], "--role", "managed-cluster-access", "--serviceaccount", "open-cluster-management:{}".format(testUsers[2]),  "-n",  clusterList[cluster]]
-      roleBindingRC, roleBindingOutput = command(createManagedClusterRoleBinding_cmd, False, no_log=True)
-      if (roleBindingRC != 0 and roleBindingOutput.find('already exists') == -1):
-        logger.error("Error creating RoleBinding for cluster {}: {}".format(clusterList[cluster], roleRC))
+  for idx, cluster in enumerate(clusterList):
+    # limited access users will get access to managed clusters only (not the hub - local-cluster)
+    if cluster != 'local-cluster':
+      # if cluster index is less than 10 create rolebinding for both users
+      if idx < 10:
+        userClusterCounts[1] += 1
+        userClusterCounts[2] += 1
+        createManagedClusterRoleBinding_cmd = ["oc", "create", "rolebinding", clusterList[idx], "--clusterrole", "managed-cluster-access", "--serviceaccount", "open-cluster-management:{}".format(testUsers[1]), "--serviceaccount", "open-cluster-management:{}".format(testUsers[2]), "-n", clusterList[idx]]
+        roleBindingRC, roleBindingOutput = command(createManagedClusterRoleBinding_cmd, False, no_log=True)
+        if (roleBindingRC != 0 and roleBindingOutput.find('already exists') == -1):
+          logger.error("Error creating RoleBinding for cluster {}: {}".format(clusterList[idx], roleRC))
+      # if cluster index is >= 10 create rolebinding for only wide access user (user get access to all but 10 clusters)
+      elif idx >= 10 and (idx < len(clusterList) - 10):
+        userClusterCounts[2] += 1
+        createManagedClusterRoleBinding_cmd = ["oc", "create", "rolebinding", clusterList[idx], "--clusterrole", "managed-cluster-access", "--serviceaccount", "open-cluster-management:{}".format(testUsers[2]), "-n", clusterList[idx]]
+        roleBindingRC, roleBindingOutput = command(createManagedClusterRoleBinding_cmd, False, no_log=True)
+        if (roleBindingRC != 0 and roleBindingOutput.find('already exists') == -1):
+          logger.error("Error creating RoleBinding for cluster {}: {}".format(clusterList[idx], roleRC))
 
-
-def getTotalResourceCount():
-  searchDB_cmd = ["oc", "get", "pods", "-n", "open-cluster-management", "-l", "app=search,name=search-postgres", "-o", "custom-columns=POD:.metadata.name", "--no-headers", "-o", "json"]
-  rc, searchDBPod = command(searchDB_cmd, False, retries=3, no_log=True)
-  route_data = json.loads(searchDBPod)
-  parsedSearchDBPod = route_data["items"][0]["metadata"]["name"]
-  total_resources_cmd = ["oc", "rsh", "-n", "open-cluster-management", parsedSearchDBPod, "psql", "-d", "search", "-U", "searchuser", "-t", "-c", "SELECT count(*) from search.resources;"]
-  rc, output = command(total_resources_cmd, False, retries=3, no_log=True)
-  logger.info("getTotalResourceCount command res: {}".format(output))
-  if rc != 0:
-    logger.error("getTotalResourceCount rc: {}".format(rc))
-  try:
-    return int(output.strip())
-  except:
+def getTotalResourceCount(URL, TOKEN):
+  headers = {"Authorization": "Bearer {}".format(TOKEN), "Content-Type": "application/json"}
+  resource_count_data = requests.post(URL, headers=headers, json=json.loads('{"query":"query searchResultCount($input: [SearchInput]) {\\n    searchResult: search(input: $input) {\\n        count\\n    }\\n}\\n","variables":{"input":[{"keywords":[],"filters":[{"property":"cluster","values":["!not-exists"]}],"limit":-1}]}}'), verify=False)
+  if resource_count_data.status_code == 200:
+    qd_json = resource_count_data.json()
+    if "errors" in qd_json:
+      logger.error("GraphQL error encountered on resource count query: {}".format(qd_json["errors"][0]["message"]))
+    elif "data" in qd_json and "searchResult" in qd_json["data"]:
+      logger.info("TotalResourceCount: {}".format(qd_json["data"]["searchResult"][0]["count"]))
+      return qd_json["data"]["searchResult"][0]["count"]
+  else:
     logger.error("Error while parsing resource count response")
     return 0
 
@@ -123,25 +125,21 @@ def measureQuery(URL, TOKEN, numRequests, queryData, queryName):
   max = 0
   avg = 0
   for x in range(numRequests):
+    headers = {"Authorization": "Bearer {}".format(TOKEN), "Content-Type": "application/json"}
     start_time = time.perf_counter()
-    search_cmd = [
-      'curl',
-      '--insecure',
-      '--location',
-      '--request',
-      'POST',
-      URL,
-      '--header',
-      'Authorization: Bearer {}'.format(TOKEN),
-      '--header',
-      'Content-Type: application/json',
-      '--data-raw',
-      queryData
-    ]
-    rc, _ = command(search_cmd, False, retries=3, no_log=True)
+    query_data = requests.post(URL, headers=headers, json=json.loads(queryData), verify=False)
     requestTime = time.perf_counter() - start_time
-    if rc != 0:
-      logger.error("Error encountered on {} iteration {}: {}".format(queryName, x, rc))
+    if query_data.status_code == 200:
+      qd_json = query_data.json()
+      if "errors" in qd_json:
+        logger.error("GraphQL error encountered on {} iteration {}: {}".format(qd_json["errors"][0]["message"]))
+      elif "data" in qd_json and "searchResult" in qd_json["data"]:
+        logger.info("search query data length: {}".format(len(qd_json["data"]["searchResult"][0]["items"])))
+      elif "data" in qd_json and "searchComplete" in qd_json["data"]:
+        logger.info("autocomplete data length: {}".format(len(qd_json["data"]["searchComplete"])))
+    else:
+      logger.error("Search query status code returned: {}".format(query_data.status_code))
+      logger.error("Error encountered on {} iteration {}: {}".format(queryName, x, query_data.text.rstrip()))
 
     queryResArray.append(requestTime)
     if requestTime < min:
@@ -168,7 +166,7 @@ def main():
   ts = datetime.now().strftime("%Y%m%d-%H%M%S")
   search_benchmark_csv_file = "{}/search-benchmark-{}.csv".format(cliargs.results_directory, ts)
   with open(search_benchmark_csv_file, "w") as csv_file:
-    csv_file.write("user,scenario,clusterCount,totalResources,sampleCount,min,max,average\n")
+    csv_file.write("user,scenario,clusterCount,totalAuthorizedResources,sampleCount,min,max,average\n")
 
   # create users
   createUsers()
@@ -184,22 +182,23 @@ def main():
 
   for idx, user in enumerate(testUsers):
     TOKEN = getUserToken(user)
-    resourceCount = getTotalResourceCount()
 
     # measure search api performance
     # Empty cache scenario only runs once as the subsequent queries would have rbac cached already and be more performant. Future iterations could potentially reset the cache each time.
-    _, _, emptyCacheAvg = measureQuery(SEARCH_API, TOKEN, 1, '{"query":"query searchResultItems($input: [SearchInput]) {\n    searchResult: search(input: $input) {\n        items\n        }\n    }\n","variables":{"input":[{"keywords":[],"filters":[{"property":"kind","values":["Pod"]}]}]}}', "query kind:Pod")
-    searchKindMin, searchKindMax, searchKindAvg = measureQuery(SEARCH_API, TOKEN, cliargs.sample_count, '{"query":"query searchResultItems($input: [SearchInput]) {\n    searchResult: search(input: $input) {\n        items\n        }\n    }\n","variables":{"input":[{"keywords":[],"filters":[{"property":"kind","values":["Pod"]}]}]}}', "query kind:Pod")
-    searchLabelMin, searchLabelMax, searchLabelAvg = measureQuery(SEARCH_API, TOKEN, cliargs.sample_count, '{"query":"query searchResultItems($input: [SearchInput]) {\n    searchResult: search(input: $input) {\n        items\n        }\n    }\n","variables":{"input":[{"keywords":[],"filters":[{"property":"label","values":["app=search"]}]}]}}', "query label:app=search")
-    searchStatusMin, searchStatusMax, searchStatusAvg = measureQuery(SEARCH_API, TOKEN, cliargs.sample_count, '{"query":"query searchResultItems($input: [SearchInput]) {\n    searchResult: search(input: $input) {\n        items\n        }\n    }\n","variables":{"input":[{"keywords":[],"filters":[{"property":"status","values":["!=Running"]}]}]}}', "query status!=Running")
-    autoNameMin, autoNameMax, autoNameAvg = measureQuery(SEARCH_API, TOKEN, cliargs.sample_count, '{"query":"query searchComplete($property:String!,$query:SearchInput,$limit:Int){\n    searchComplete(property:$property,query:$query,limit:$limit)\n}\n","variables":{"property":"name","query":{"keywords":[],"filters":[],"limit":10000},"limit":10000}}', "autocomplete name")
-    autoLabelMin, autoLabelMax, autoLabelAvg = measureQuery(SEARCH_API, TOKEN, cliargs.sample_count, '{"query":"query searchComplete($property:String!,$query:SearchInput,$limit:Int){\n    searchComplete(property:$property,query:$query,limit:$limit)\n}\n","variables":{"property":"label","query":{"keywords":[],"filters":[],"limit":10000},"limit":10000}}', "autocomplete label")
-    autoStatusMin, autoStatusMax, autoStatusAvg = measureQuery(SEARCH_API, TOKEN, cliargs.sample_count, '{"query":"query searchComplete($property:String!,$query:SearchInput,$limit:Int){\n    searchComplete(property:$property,query:$query,limit:$limit)\n}\n","variables":{"property":"status","query":{"keywords":[],"filters":[],"limit":10000},"limit":10000}}', "autocomplete status")
+    _, _, emptyCacheAvg = measureQuery(SEARCH_API, TOKEN, 1, '{"query":"query searchResultItems($input: [SearchInput]) {\\n    searchResult: search(input: $input) {\\n        items\\n    }\\n}\\n","variables":{"input":[{"keywords":[],"filters":[{"property":"kind","values":["Pod"]}],"limit":-1}]}}', "query kind:Pod")
+    searchKindMin, searchKindMax, searchKindAvg = measureQuery(SEARCH_API, TOKEN, cliargs.sample_count, '{"query":"query searchResultItems($input: [SearchInput]) {\\n    searchResult: search(input: $input) {\\n        items\\n    }\\n}\\n","variables":{"input":[{"keywords":[],"filters":[{"property":"kind","values":["Pod"]}],"limit":-1}]}}', "query kind:Pod")
+    searchLabelMin, searchLabelMax, searchLabelAvg = measureQuery(SEARCH_API, TOKEN, cliargs.sample_count, '{"query":"query searchResultItems($input: [SearchInput]) {\\n    searchResult: search(input: $input) {\\n        items\\n    }\\n}\\n","variables":{"input":[{"keywords":[],"filters":[{"property":"label","values":["vendor=OpenShift"]}],"limit":-1}]}}', "query label:vendor=OpenShift")
+    searchStatusMin, searchStatusMax, searchStatusAvg = measureQuery(SEARCH_API, TOKEN, cliargs.sample_count, '{"query":"query searchResultItems($input: [SearchInput]) {\\n    searchResult: search(input: $input) {\\n        items\\n    }\\n}\\n","variables":{"input":[{"keywords":[],"filters":[{"property":"status","values":["!=Running"]}],"limit":-1}]}}', "query status!=Running")
+    autoNameMin, autoNameMax, autoNameAvg = measureQuery(SEARCH_API, TOKEN, cliargs.sample_count, '{"query":"query searchComplete($property:String!,$query:SearchInput,$limit:Int){\\n    searchComplete(property:$property,query:$query,limit:$limit)\\n}\\n","variables":{"property":"name","query":{"keywords":[],"filters":[]},"limit":-1}}', "autocomplete name")
+    autoLabelMin, autoLabelMax, autoLabelAvg = measureQuery(SEARCH_API, TOKEN, cliargs.sample_count, '{"query":"query searchComplete($property:String!,$query:SearchInput,$limit:Int){\\n    searchComplete(property:$property,query:$query,limit:$limit)\\n}\\n","variables":{"property":"label","query":{"keywords":[],"filters":[]},"limit":-1}}', "autocomplete label")
+    autoStatusMin, autoStatusMax, autoStatusAvg = measureQuery(SEARCH_API, TOKEN, cliargs.sample_count, '{"query":"query searchComplete($property:String!,$query:SearchInput,$limit:Int){\\n    searchComplete(property:$property,query:$query,limit:$limit)\\n}\\n","variables":{"property":"status","query":{"keywords":[],"filters":[]},"limit":-1}}', "autocomplete status")
+
+    resourceCount = getTotalResourceCount(SEARCH_API, TOKEN)
 
     with open(search_benchmark_csv_file, "a") as csv_file:
       csv_file.write("{},{},{},{},{},{},{},{}\n".format(user, "Empty cache search [kind:Pod]", userClusterCounts[idx], resourceCount, 1, "", "", emptyCacheAvg))
       csv_file.write("{},{},{},{},{},{},{},{}\n".format(user, "search [kind:Pod]", userClusterCounts[idx], resourceCount, cliargs.sample_count, searchKindMin, searchKindMax, searchKindAvg))
-      csv_file.write("{},{},{},{},{},{},{},{}\n".format(user, "search [label:app=search]", userClusterCounts[idx], resourceCount, cliargs.sample_count, searchLabelMin, searchLabelMax, searchLabelAvg))
+      csv_file.write("{},{},{},{},{},{},{},{}\n".format(user, "search [label:vendor=OpenShift]", userClusterCounts[idx], resourceCount, cliargs.sample_count, searchLabelMin, searchLabelMax, searchLabelAvg))
       csv_file.write("{},{},{},{},{},{},{},{}\n".format(user, "search [status!=Running]", userClusterCounts[idx], resourceCount, cliargs.sample_count, searchStatusMin, searchStatusMax, searchStatusAvg))
       csv_file.write("{},{},{},{},{},{},{},{}\n".format(user, "autocomplete [name]", userClusterCounts[idx], resourceCount, cliargs.sample_count, autoNameMin, autoNameMax, autoNameAvg))
       csv_file.write("{},{},{},{},{},{},{},{}\n".format(user, "autocomplete [label]", userClusterCounts[idx], resourceCount, cliargs.sample_count, autoLabelMin, autoLabelMax, autoLabelAvg))


### PR DESCRIPTION
Added rbac users:
- search-limited-access-user: access to only 10 clusters (not including local-cluster)
- search-wide-access-user: access to n - 10 clusters (not including local-cluster)

Updated search query to use python requests lib for better response handling.

Better error handling on search queries for transparency in test logs. *Graphql can return errors as part of a successful request that previously were not being handled. 

Fixed search query syntax (`\n` chars need to be `\\n`)

Removed default limit for (fixed by adding `limit: -1`)