### PR TITLE
upgrading ansible collection awx in bootstrap

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,3 +3,4 @@ python3 -m venv .venv
 source .venv/bin/activate
 pip3 install --upgrade pip
 pip3 install -r requirements.txt
+ansible-galaxy collection install --upgrade awx.awx


### PR DESCRIPTION
the aap-configure role uses the awx.awx.token module The version shipped in RHEL 8.2 is 19.x. Version 21.5 is required for IPv6 support.

This addition to bootsrap will install the latest version of awx.

if it's already latest the command will return 0 indicating awx is already up to date:
 # ansible-galaxy collection install --upgrade awx.awx
Starting galaxy collection install process
Process install dependency map
Starting collection install process
Skipping 'awx.awx:23.8.0' as it is already installed
 # echo $?
0